### PR TITLE
Create manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,9 @@
+{
+  "domain": "hwam_stove",
+  "name": "HWAM Smart Stove",
+  "documentation": "https://github.com/mvn23/hwam_stove",
+  "dependencies": [],
+  "codeowners": [],
+  "requirements": [],
+  "iot_class": "local_polling"
+}

--- a/manifest.json
+++ b/manifest.json
@@ -5,5 +5,6 @@
   "dependencies": [],
   "codeowners": [],
   "requirements": [],
+  "version": "0.0.1",
   "iot_class": "local_polling"
 }


### PR DESCRIPTION
Add `manifest.json` required for newer Home Assistant versions

fixes #3 