### PR TITLE
Use entity translation keys

### DIFF
--- a/binary_sensor.py
+++ b/binary_sensor.py
@@ -252,8 +252,6 @@ async def async_setup_entry(
 class HwamStoveBinarySensor(HWAMStoveEntity, BinarySensorEntity):
     """Representation of a HWAM Stove binary sensor."""
 
-    _attr_has_entity_name = True
-
     def __init__(self, stove_device, entity_description, entity_id):
         """Initialize the binary sensor."""
         super().__init__(stove_device, entity_description)

--- a/binary_sensor.py
+++ b/binary_sensor.py
@@ -47,8 +47,8 @@ class HWAMStoveBinarySensorListEntityDescription(
 BINARY_SENSOR_DESCRIPTIONS = [
     HWAMStoveBinarySensorEntityDescription(
         key=pystove.DATA_REFILL_ALARM,
+        translation_key="refill_alarm",
         device_identifier=StoveDeviceIdentifier.STOVE,
-        name_format="Refill Alarm {}",
     ),
 ]
 
@@ -56,154 +56,154 @@ BINARY_SENSOR_LIST_DESCRIPTIONS = [
     # General (any) maintenance alarm
     HWAMStoveBinarySensorListEntityDescription(
         key=pystove.DATA_MAINTENANCE_ALARMS,
+        translation_key="maintenance_alarms",
         device_identifier=StoveDeviceIdentifier.STOVE,
         value_source_key=pystove.DATA_MAINTENANCE_ALARMS,
         device_class=BinarySensorDeviceClass.PROBLEM,
-        name_format="Maintenance Alarm {}",
         alarm_str=None,
     ),
     # Stove Backup Battery Low
     HWAMStoveBinarySensorListEntityDescription(
         key=f"{pystove.DATA_MAINTENANCE_ALARMS}_backup_battery_low",
+        translation_key="maintenance_alarms_backup_battery_low",
         device_identifier=StoveDeviceIdentifier.STOVE,
         value_source_key=pystove.DATA_MAINTENANCE_ALARMS,
         device_class=BinarySensorDeviceClass.BATTERY,
-        name_format="Stove Backup Battery Low {}",
         alarm_str=pystove.MAINTENANCE_ALARMS[0],
     ),
     # O2 Sensor Fault
     HWAMStoveBinarySensorListEntityDescription(
         key=f"{pystove.DATA_MAINTENANCE_ALARMS}_o2_sensor_fault",
+        translation_key="maintenance_alarms_o2_sensor_fault",
         device_identifier=StoveDeviceIdentifier.STOVE,
         value_source_key=pystove.DATA_MAINTENANCE_ALARMS,
         device_class=BinarySensorDeviceClass.PROBLEM,
-        name_format="O2 Sensor Fault {}",
         alarm_str=pystove.MAINTENANCE_ALARMS[1],
     ),
     # O2 Sensor Offset
     HWAMStoveBinarySensorListEntityDescription(
         key=f"{pystove.DATA_MAINTENANCE_ALARMS}_o2_sensor_offset",
+        translation_key="maintenance_alarms_o2_sensor_offset",
         device_identifier=StoveDeviceIdentifier.STOVE,
         value_source_key=pystove.DATA_MAINTENANCE_ALARMS,
         device_class=BinarySensorDeviceClass.PROBLEM,
-        name_format="O2 Sensor Offset {}",
         alarm_str=pystove.MAINTENANCE_ALARMS[2],
     ),
     # Stove Temperature Sensor Fault
     HWAMStoveBinarySensorListEntityDescription(
         key=f"{pystove.DATA_MAINTENANCE_ALARMS}_stove_temp_sensor_fault",
+        translation_key="maintenance_alarms_stove_temp_sensor_fault",
         device_identifier=StoveDeviceIdentifier.STOVE,
         value_source_key=pystove.DATA_MAINTENANCE_ALARMS,
         device_class=BinarySensorDeviceClass.PROBLEM,
-        name_format="Stove Temperature Sensor Fault {}",
         alarm_str=pystove.MAINTENANCE_ALARMS[3],
     ),
     # Room Temperature Sensor Fault
     HWAMStoveBinarySensorListEntityDescription(
         key=f"{pystove.DATA_MAINTENANCE_ALARMS}_room_temp_sensor_fault",
+        translation_key="maintenance_alarms_room_temp_sensor_fault",
         device_identifier=StoveDeviceIdentifier.REMOTE,
         value_source_key=pystove.DATA_MAINTENANCE_ALARMS,
         device_class=BinarySensorDeviceClass.PROBLEM,
-        name_format="Room Temperature Sensor Fault {}",
         alarm_str=pystove.MAINTENANCE_ALARMS[4],
     ),
     # Communication Fault
     HWAMStoveBinarySensorListEntityDescription(
         key=f"{pystove.DATA_MAINTENANCE_ALARMS}_communication_fault",
+        translation_key="maintenance_alarms_communication_fault",
         device_identifier=StoveDeviceIdentifier.STOVE,
         value_source_key=pystove.DATA_MAINTENANCE_ALARMS,
         device_class=BinarySensorDeviceClass.PROBLEM,
-        name_format="Communication Fault {}",
         alarm_str=pystove.MAINTENANCE_ALARMS[5],
     ),
     # Room Temperature Sensor Battery Low
     HWAMStoveBinarySensorListEntityDescription(
         key=f"{pystove.DATA_MAINTENANCE_ALARMS}_room_temp_sensor_battery_low",
+        translation_key="maintenance_alarms_room_temp_sensor_battery_low",
         device_identifier=StoveDeviceIdentifier.REMOTE,
         value_source_key=pystove.DATA_MAINTENANCE_ALARMS,
         device_class=BinarySensorDeviceClass.PROBLEM,
-        name_format="Room Temperature Sensor Battery Low {}",
         alarm_str=pystove.MAINTENANCE_ALARMS[6],
     ),
     # General (any) safety alarm
     HWAMStoveBinarySensorListEntityDescription(
         key=pystove.DATA_SAFETY_ALARMS,
+        translation_key="safety_alarms",
         device_identifier=StoveDeviceIdentifier.STOVE,
         value_source_key=pystove.DATA_SAFETY_ALARMS,
         device_class=BinarySensorDeviceClass.SAFETY,
-        name_format="Safety Alarm {}",
         alarm_str=None,
     ),
     # Valve Fault, same as [1] and [2].
     HWAMStoveBinarySensorListEntityDescription(
         key=f"{pystove.DATA_SAFETY_ALARMS}_valve_fault",
+        translation_key="safety_alarms_valve_fault",
         device_identifier=StoveDeviceIdentifier.STOVE,
         value_source_key=pystove.DATA_SAFETY_ALARMS,
         device_class=BinarySensorDeviceClass.SAFETY,
-        name_format="Valve Fault {}",
         alarm_str=pystove.SAFETY_ALARMS[0],
     ),
     # Bad Configuration
     HWAMStoveBinarySensorListEntityDescription(
         key=f"{pystove.DATA_SAFETY_ALARMS}_bad_configuration",
+        translation_key="safety_alarms_bad_configuration",
         device_identifier=StoveDeviceIdentifier.STOVE,
         value_source_key=pystove.DATA_SAFETY_ALARMS,
         device_class=BinarySensorDeviceClass.SAFETY,
-        name_format="Bad Configuration {}",
         alarm_str=pystove.SAFETY_ALARMS[3],
     ),
     # Valve Disconnect, same as [5] and [6]
     HWAMStoveBinarySensorListEntityDescription(
         key=f"{pystove.DATA_SAFETY_ALARMS}_valve_disconnect",
+        translation_key="safety_alarms_valve_disconnect",
         device_identifier=StoveDeviceIdentifier.STOVE,
         value_source_key=pystove.DATA_SAFETY_ALARMS,
         device_class=BinarySensorDeviceClass.SAFETY,
-        name_format="Valve Disconnect {}",
         alarm_str=pystove.SAFETY_ALARMS[4],
     ),
     # Valve Calibration Error, same as [8] and [9]
     HWAMStoveBinarySensorListEntityDescription(
         key=f"{pystove.DATA_SAFETY_ALARMS}_valve_calibration_error",
+        translation_key="safety_alarms_valve_calibration_error",
         device_identifier=StoveDeviceIdentifier.STOVE,
         value_source_key=pystove.DATA_SAFETY_ALARMS,
         device_class=BinarySensorDeviceClass.SAFETY,
-        name_format="Valve Calibration Error {}",
         alarm_str=pystove.SAFETY_ALARMS[7],
     ),
     # Overheating
     HWAMStoveBinarySensorListEntityDescription(
         key=f"{pystove.DATA_SAFETY_ALARMS}_stove_overheat",
+        translation_key="safety_alarms_stove_overheat",
         device_identifier=StoveDeviceIdentifier.STOVE,
         value_source_key=pystove.DATA_SAFETY_ALARMS,
         device_class=BinarySensorDeviceClass.SAFETY,
-        name_format="Stove Overheat {}",
         alarm_str=pystove.SAFETY_ALARMS[10],
     ),
     # Door Open Too Long
     HWAMStoveBinarySensorListEntityDescription(
         key=f"{pystove.DATA_SAFETY_ALARMS}_door_open_too_long",
+        translation_key="safety_alarms_door_open_too_long",
         device_identifier=StoveDeviceIdentifier.STOVE,
         value_source_key=pystove.DATA_SAFETY_ALARMS,
         device_class=BinarySensorDeviceClass.SAFETY,
-        name_format="Door Open Too Long {}",
         alarm_str=pystove.SAFETY_ALARMS[11],
     ),
     # Manual Safety Alarm
     HWAMStoveBinarySensorListEntityDescription(
         key=f"{pystove.DATA_SAFETY_ALARMS}_manual_safety_alarm",
+        translation_key="safety_alarms_manual_safety_alarm",
         device_identifier=StoveDeviceIdentifier.STOVE,
         value_source_key=pystove.DATA_SAFETY_ALARMS,
         device_class=BinarySensorDeviceClass.SAFETY,
-        name_format="Manual Safety Alarm {}",
         alarm_str=pystove.SAFETY_ALARMS[12],
     ),
     # Stove Sensor Fault
     HWAMStoveBinarySensorListEntityDescription(
         key=f"{pystove.DATA_SAFETY_ALARMS}_stove_sensor_fault",
+        translation_key="safety_alarms_stove_sensor_fault",
         device_identifier=StoveDeviceIdentifier.STOVE,
         value_source_key=pystove.DATA_SAFETY_ALARMS,
         device_class=BinarySensorDeviceClass.SAFETY,
-        name_format="Stove Sensor Fault {}",
         alarm_str=pystove.SAFETY_ALARMS[13],
     ),
 ]
@@ -251,6 +251,8 @@ async def async_setup_entry(
 
 class HwamStoveBinarySensor(HWAMStoveEntity, BinarySensorEntity):
     """Representation of a HWAM Stove binary sensor."""
+
+    _attr_has_entity_name = True
 
     def __init__(self, stove_device, entity_description, entity_id):
         """Initialize the binary sensor."""

--- a/entity.py
+++ b/entity.py
@@ -10,13 +10,13 @@ from . import DOMAIN, StoveDevice, StoveDeviceIdentifier
 class HWAMStoveEntityDescription(EntityDescription):
     """Describe common hwam_stove entity properties."""
 
-    name_format: str | None = None
     device_identifier: StoveDeviceIdentifier
 
 
 class HWAMStoveEntity(Entity):
     """Represent a hwam_stove entity."""
 
+    _attr_has_entity_name = True
     _attr_should_poll = False
     entity_description: HWAMStoveEntityDescription
 
@@ -36,10 +36,6 @@ class HWAMStoveEntity(Entity):
         )
         self._stove_device = stove_device
         self.entity_description = entity_description
-        if self.entity_description.name_format is not None:
-            self._attr_name = self.entity_description.name_format.format(
-                stove_device.stove.name
-            )
 
     async def async_added_to_hass(self):
         """Subscribe to updates."""

--- a/entity.py
+++ b/entity.py
@@ -10,7 +10,7 @@ from . import DOMAIN, StoveDevice, StoveDeviceIdentifier
 class HWAMStoveEntityDescription(EntityDescription):
     """Describe common hwam_stove entity properties."""
 
-    name_format: str
+    name_format: str | None = None
     device_identifier: StoveDeviceIdentifier
 
 
@@ -36,6 +36,10 @@ class HWAMStoveEntity(Entity):
         )
         self._stove_device = stove_device
         self.entity_description = entity_description
+        if self.entity_description.name_format is not None:
+            self._attr_name = self.entity_description.name_format.format(
+                stove_device.stove.name
+            )
 
     async def async_added_to_hass(self):
         """Subscribe to updates."""
@@ -49,8 +53,3 @@ class HWAMStoveEntity(Entity):
         """Receive updates from the component."""
         # Must be implemented at the platform level.
         raise NotImplementedError
-
-    @property
-    def name(self) -> str:
-        """Set the friendly name."""
-        return self.entity_description.name_format.format(self._stove_device.stove.name)

--- a/fan.py
+++ b/fan.py
@@ -57,8 +57,6 @@ async def async_setup_entry(
 class StoveBurnLevel(HWAMStoveEntity, FanEntity):
     """Representation of a fan."""
 
-    _attr_has_entity_name = True
-
     def __init__(self, stove_device, entity_description):
         super().__init__(stove_device, entity_description)
         self._burn_level = 0

--- a/fan.py
+++ b/fan.py
@@ -47,8 +47,8 @@ async def async_setup_entry(
         stove_hub,
         HWAMStoveFanEntityDescription(
             key="fan_entity",
+            translation_key="fan_entity",
             device_identifier=StoveDeviceIdentifier.STOVE,
-            name_format="Burn Level {}",
         ),
     )
     async_add_entities([stove])
@@ -56,6 +56,8 @@ async def async_setup_entry(
 
 class StoveBurnLevel(HWAMStoveEntity, FanEntity):
     """Representation of a fan."""
+
+    _attr_has_entity_name = True
 
     def __init__(self, stove_device, entity_description):
         super().__init__(stove_device, entity_description)

--- a/sensor.py
+++ b/sensor.py
@@ -38,108 +38,108 @@ class HWAMStoveSensorEntityDescription(
 SENSOR_DESCRIPTIONS = [
     HWAMStoveSensorEntityDescription(
         key=pystove.DATA_ALGORITHM,
+        translation_key="algorithm",
         device_identifier=StoveDeviceIdentifier.STOVE,
-        name_format="Algorithm {}",
     ),
     HWAMStoveSensorEntityDescription(
         key=pystove.DATA_BURN_LEVEL,
+        translation_key="burn_level",
         device_identifier=StoveDeviceIdentifier.STOVE,
-        name_format="Burn Level {}",
     ),
     HWAMStoveSensorEntityDescription(
         key=pystove.DATA_MAINTENANCE_ALARMS,
+        translation_key="maintenance_alarms",
         device_identifier=StoveDeviceIdentifier.STOVE,
-        name_format="Maintenance Alarms {}",
     ),
     HWAMStoveSensorEntityDescription(
         key=pystove.DATA_MESSAGE_ID,
+        translation_key="message_id",
         device_identifier=StoveDeviceIdentifier.STOVE,
-        name_format="Message ID {}",
     ),
     HWAMStoveSensorEntityDescription(
         key=pystove.DATA_NEW_FIREWOOD_ESTIMATE,
+        translation_key="new_firewood_estimate",
         device_identifier=StoveDeviceIdentifier.STOVE,
-        name_format="New Firewood Estimate {}",
     ),
     HWAMStoveSensorEntityDescription(
         key=pystove.DATA_NIGHT_BEGIN_TIME,
+        translation_key="night_begin_time",
         device_identifier=StoveDeviceIdentifier.STOVE,
-        name_format="Night Begin Time {}",
     ),
     HWAMStoveSensorEntityDescription(
         key=pystove.DATA_NIGHT_END_TIME,
+        translation_key="night_end_time",
         device_identifier=StoveDeviceIdentifier.STOVE,
-        name_format="Night End Time {}",
     ),
     HWAMStoveSensorEntityDescription(
         key=pystove.DATA_NIGHT_LOWERING,
+        translation_key="night_lowering",
         device_identifier=StoveDeviceIdentifier.STOVE,
-        name_format="Night Lowering {}",
     ),
     HWAMStoveSensorEntityDescription(
         key=pystove.DATA_OPERATION_MODE,
+        translation_key="operation_mode",
         device_identifier=StoveDeviceIdentifier.STOVE,
-        name_format="Operation Mode {}",
     ),
     HWAMStoveSensorEntityDescription(
         key=pystove.DATA_OXYGEN_LEVEL,
+        translation_key="oxygen_level",
         device_identifier=StoveDeviceIdentifier.STOVE,
         native_unit_of_measurement=PERCENTAGE,
-        name_format="Oxygen Level {}",
     ),
     HWAMStoveSensorEntityDescription(
         key=pystove.DATA_PHASE,
+        translation_key="phase",
         device_identifier=StoveDeviceIdentifier.STOVE,
-        name_format="Phase {}",
     ),
     HWAMStoveSensorEntityDescription(
         key=pystove.DATA_ROOM_TEMPERATURE,
+        translation_key="room_temperature",
         device_identifier=StoveDeviceIdentifier.REMOTE,
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
-        name_format="Room Temperature {}",
     ),
     HWAMStoveSensorEntityDescription(
         key=pystove.DATA_SAFETY_ALARMS,
+        translation_key="safety_alarms",
         device_identifier=StoveDeviceIdentifier.STOVE,
-        name_format="Safety Alarms {}",
     ),
     HWAMStoveSensorEntityDescription(
         key=pystove.DATA_STOVE_TEMPERATURE,
+        translation_key="stove_temperature",
         device_identifier=StoveDeviceIdentifier.STOVE,
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
-        name_format="Stove Temperature {}",
     ),
     HWAMStoveSensorEntityDescription(
         key=pystove.DATA_TIME_SINCE_REMOTE_MSG,
+        translation_key="time_since_remote_message",
         device_identifier=StoveDeviceIdentifier.STOVE,
-        name_format="Time Since Remote Message {}",
     ),
     HWAMStoveSensorEntityDescription(
         key=pystove.DATA_DATE_TIME,
+        translation_key="date_and_time",
         device_identifier=StoveDeviceIdentifier.STOVE,
-        name_format="Date and time {}",
     ),
     HWAMStoveSensorEntityDescription(
         key=pystove.DATA_TIME_TO_NEW_FIREWOOD,
+        translation_key="time_to_new_firewood",
         device_identifier=StoveDeviceIdentifier.STOVE,
-        name_format="Time To New Firewood {}",
     ),
     HWAMStoveSensorEntityDescription(
         key=pystove.DATA_VALVE1_POSITION,
+        translation_key="valve_1_position",
         device_identifier=StoveDeviceIdentifier.STOVE,
-        name_format="Valve 1 Position {}",
     ),
     HWAMStoveSensorEntityDescription(
         key=pystove.DATA_VALVE2_POSITION,
+        translation_key="valve_2_position",
         device_identifier=StoveDeviceIdentifier.STOVE,
-        name_format="Valve 2 Position {}",
     ),
     HWAMStoveSensorEntityDescription(
         key=pystove.DATA_VALVE3_POSITION,
+        translation_key="valve_3_position",
         device_identifier=StoveDeviceIdentifier.STOVE,
-        name_format="Valve 3 Position {}",
     ),
 ]
 
@@ -169,6 +169,8 @@ async def async_setup_entry(
 
 class HwamStoveSensor(HWAMStoveEntity, SensorEntity):
     """Representation of a HWAM Stove sensor."""
+
+    _attr_has_entity_name = True
 
     def __init__(self, stove_device, entity_description, entity_id):
         """Initialize the sensor."""

--- a/sensor.py
+++ b/sensor.py
@@ -170,8 +170,6 @@ async def async_setup_entry(
 class HwamStoveSensor(HWAMStoveEntity, SensorEntity):
     """Representation of a HWAM Stove sensor."""
 
-    _attr_has_entity_name = True
-
     def __init__(self, stove_device, entity_description, entity_id):
         """Initialize the sensor."""
         super().__init__(stove_device, entity_description)
@@ -180,7 +178,6 @@ class HwamStoveSensor(HWAMStoveEntity, SensorEntity):
         self._value = None
         self._device_class = entity_description.device_class
         self._unit = entity_description.native_unit_of_measurement
-        self._name_format = entity_description.name_format
 
     async def receive_report(self, status):
         """Handle status updates from the component."""

--- a/translations/en.json
+++ b/translations/en.json
@@ -79,7 +79,12 @@
       "safety_alarms_stove_sensor_fault": {
         "name": "Sensor Fault"
       }
-    }  
+    },
+    "fan": {
+      "fan_entity": {
+        "name": "Burn Level"
+      }
+    }
   },
   "issues": {
     "deprecated_import_from_configuration_yaml": {

--- a/translations/en.json
+++ b/translations/en.json
@@ -23,6 +23,64 @@
       "name": "HWAM Smart Stove"
     }
   },
+  "entity": {
+    "binary_sensor": {
+      "refill_alarm": {
+        "name": "Refill Alarm"
+      },
+      "maintenance_alarms": {
+        "name": "Maintenance Alarm"
+      },
+      "maintenance_alarms_backup_battery_low": {
+        "name": "Backup Battery Low"
+      },
+      "maintenance_alarms_o2_sensor_fault": {
+        "name": "O2 Sensor Fault"
+      },
+      "maintenance_alarms_o2_sensor_offset": {
+        "name": "O2 Sensor Offset"
+      },
+      "maintenance_alarms_stove_temp_sensor_fault": {
+        "name": "Temperature Sensor Fault"
+      },
+      "maintenance_alarms_room_temp_sensor_fault": {
+        "name": "Temperature Sensor Fault"
+      },
+      "maintenance_alarms_communication_fault": {
+        "name": "Communication Fault"
+      },
+      "maintenance_alarms_room_temp_sensor_battery_low": {
+        "name": "Battery Low"
+      },
+      "safety_alarms": {
+        "name": "Safety Alarm"
+      },
+      "safety_alarms_valve_fault": {
+        "name": "Valve Fault"
+      },
+      "safety_alarms_bad_configuration": {
+        "name": "Bad Configuration"
+      },
+      "safety_alarms_valve_disconnect": {
+        "name": "Valve Disconnect"
+      },
+      "safety_alarms_valve_calibration_error": {
+        "name": "Valve Calibration Error"
+      },
+      "safety_alarms_stove_overheat": {
+        "name": "Overheat Alarm"
+      },
+      "safety_alarms_door_open_too_long": {
+        "name": "Door Open Too Long"
+      },
+      "safety_alarms_manual_safety_alarm": {
+        "name": "Manual Safety Alarm"
+      },
+      "safety_alarms_stove_sensor_fault": {
+        "name": "Sensor Fault"
+      }
+    }  
+  },
   "issues": {
     "deprecated_import_from_configuration_yaml": {
       "title": "Deprecated configuration",

--- a/translations/en.json
+++ b/translations/en.json
@@ -84,6 +84,68 @@
       "fan_entity": {
         "name": "Burn Level"
       }
+    },
+    "sensor": {
+      "algorithm": {
+        "name": "Algorithm"
+      },
+      "burn_level": {
+        "name": "Burn Level"
+      },
+      "maintenance_alarms": {
+        "name": "Maintenance Alarms"
+      },
+      "message_id": {
+        "name": "Message ID"
+      },
+      "new_firewood_estimate": {
+        "name": "New Firewood Estimate"
+      },
+      "night_begin_time": {
+        "name": "Night Begin Time"
+      },
+      "night_end_time": {
+        "name": "Night End Time"
+      },
+      "night_lowering": {
+        "name": "Night Lowering"
+      },
+      "operation_mode": {
+        "name": "Operation Mode"
+      },
+      "oxygen_level": {
+        "name": "Oxygen Level"
+      },
+      "phase": {
+        "name": "Phase"
+      },
+      "room_temperature": {
+        "name": "Temperature"
+      },
+      "safety_alarms": {
+        "name": "Safety Alarms"
+      },
+      "stove_temperature": {
+        "name": "Temperature"
+      },
+      "time_since_remote_message": {
+        "name": "Time Since Remote Message"
+      },
+      "date_and_time": {
+        "name": "Date and time"
+      },
+      "time_to_new_firewood": {
+        "name": "Time To New Firewood"
+      },
+      "valve_1_position": {
+        "name": "Valve 1 Position"
+      },
+      "valve_2_position": {
+        "name": "Valve 2 Position"
+      },
+      "valve_3_position": {
+        "name": "Valve 3 Position"
+      }
     }
   },
   "issues": {


### PR DESCRIPTION
Remove the use of `name_format` in favor of `translation_key` support.