### PR TITLE
Add switch platform

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -132,13 +132,6 @@ def register_services(hass):
             vol.Optional(ATTR_TIME, default=datetime.now().time()): cv.time,
         }
     )
-    service_basic_schema = vol.Schema(
-        {
-            vol.Required(ATTR_STOVE_NAME): vol.All(
-                cv.string, vol.In(hass.data[DATA_HWAM_STOVE][DATA_STOVES])
-            ),
-        }
-    )
 
     async def set_night_lowering_hours(call):
         """Set night lowering hours on the stove."""
@@ -155,66 +148,6 @@ def register_services(hass):
         SERVICE_SET_NIGHT_LOWERING_HOURS,
         set_night_lowering_hours,
         service_set_night_lowering_hours_schema,
-    )
-
-    async def enable_night_lowering(call):
-        """Enable night lowering."""
-        stove_name = call.data[ATTR_STOVE_NAME]
-        stove_device = hass.data[DATA_HWAM_STOVE][DATA_STOVES].get(stove_name)
-        if stove_device is None:
-            return
-        await stove_device.stove.set_night_lowering(True)
-
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_ENABLE_NIGHT_LOWERING,
-        enable_night_lowering,
-        service_basic_schema,
-    )
-
-    async def disable_night_lowering(call):
-        """Disable night lowering."""
-        stove_name = call.data[ATTR_STOVE_NAME]
-        stove_device = hass.data[DATA_HWAM_STOVE][DATA_STOVES].get(stove_name)
-        if stove_device is None:
-            return
-        await stove_device.stove.set_night_lowering(False)
-
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_DISABLE_NIGHT_LOWERING,
-        disable_night_lowering,
-        service_basic_schema,
-    )
-
-    async def enable_remote_refill_alarm(call):
-        """Enable remote refill alarm."""
-        stove_name = call.data[ATTR_STOVE_NAME]
-        stove_device = hass.data[DATA_HWAM_STOVE][DATA_STOVES].get(stove_name)
-        if stove_device is None:
-            return
-        await stove_device.stove.set_remote_refill_alarm(True)
-
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_ENABLE_REMOTE_REFILL_ALARM,
-        enable_remote_refill_alarm,
-        service_basic_schema,
-    )
-
-    async def disable_remote_refill_alarm(call):
-        """Disable remote refill alarm."""
-        stove_name = call.data[ATTR_STOVE_NAME]
-        stove_device = hass.data[DATA_HWAM_STOVE][DATA_STOVES].get(stove_name)
-        if stove_device is None:
-            return
-        await stove_device.stove.set_remote_refill_alarm(False)
-
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_DISABLE_REMOTE_REFILL_ALARM,
-        disable_remote_refill_alarm,
-        service_basic_schema,
     )
 
     async def set_device_clock(call):

--- a/__init__.py
+++ b/__init__.py
@@ -15,6 +15,7 @@ from homeassistant.const import (
     CONF_HOST,
     CONF_MONITORED_VARIABLES,
     CONF_NAME,
+    Platform,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv, issue_registry as ir
@@ -59,9 +60,10 @@ CONFIG_SCHEMA = vol.Schema(
 )
 
 PLATFORMS = [
-    "binary_sensor",
-    "fan",
-    "sensor",
+    Platform.BINARY_SENSOR,
+    Platform.FAN,
+    Platform.SENSOR,
+    Platform.SWITCH,
 ]
 
 _LOGGER = logging.getLogger(__name__)

--- a/services.yaml
+++ b/services.yaml
@@ -12,30 +12,6 @@ set_clock:
       description: Optional time in 24h format to set on the stove. Defaults to the current time.
       example: '19:34'
 
-enable_remote_refill_alarm:
-  description: Enable the remote refill alarm option on the HWAM stove.
-  fields:
-    stove_name:
-      description: The stove name as specified in configuration.yaml.
-
-disable_remote_refill_alarm:
-  description: Disable the remote refill alarm option on the HWAM stove.
-  fields:
-    stove_name:
-      description: The stove name as specified in configuration.yaml.
-
-enable_night_lowering:
-  description: Enable the night lowering function on the HWAM stove.
-  fields:
-    stove_name:
-      description: The stove name as specified in configuration.yaml.
-
-disable_night_lowering:
-  description: Disable the night lowering function on the HWAM stove.
-  fields:
-    stove_name:
-      description: The stove name as specified in configuration.yaml.
-
 set_night_lowering_hours:
   description: Set the night lowering hours on the HWAM stove. At least one of 'start_time' or 'end_time' must be provided.
   fields:

--- a/switch.py
+++ b/switch.py
@@ -83,12 +83,19 @@ class HwamStoveBinarySensor(HWAMStoveEntity, SwitchEntity):
         self._attr_is_on = self.entity_description.state_func(
             self.coordinator.data[self.entity_description.key]
         )
-        self.async_schedule_update_ha_state()
+        self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs):
         """Turn off the switch."""
-        await self.entity_description.turn_off_func(self.coordinator)
+        success = await self.entity_description.turn_off_func(self.coordinator)
+        if success:
+            self._attr_is_on = False
+            self.async_schedule_update_ha_state()
+
     
     async def async_turn_on(self, **kwargs):
         """Turn on the switch."""
-        await self.entity_description.turn_on_func(self.coordinator)
+        success = await self.entity_description.turn_on_func(self.coordinator)
+        if success:
+            self._attr_is_on = True
+            self.async_schedule_update_ha_state()

--- a/switch.py
+++ b/switch.py
@@ -1,0 +1,94 @@
+"""
+Support for HWAM Stove switches.
+
+For more details about this platform, please refer to the documentation at
+https://github.com/mvn23/hwam_stove
+"""
+
+from dataclasses import dataclass
+import logging
+from typing import Any, Awaitable, Callable
+
+from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_NAME
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+import pystove
+
+from . import DATA_HWAM_STOVE, DATA_STOVES
+from .const import StoveDeviceIdentifier
+from .coordinator import StoveCoordinator
+from .entity import HWAMStoveEntity, HWAMStoveEntityDescription
+
+
+@dataclass(frozen=True, kw_only=True)
+class HWAMStoveSwitchEntityDescription(
+    SwitchEntityDescription,
+    HWAMStoveEntityDescription,
+):
+    """Describes a hwam_stove switch entity."""
+
+    state_func: Callable[[Any], bool] = bool
+    turn_off_func: Callable[[StoveCoordinator], Awaitable[bool]]
+    turn_on_func: Callable[[StoveCoordinator], Awaitable[bool]]
+
+
+SWITCH_DESCRIPTIONS = [
+    HWAMStoveSwitchEntityDescription(
+        key=pystove.DATA_NIGHT_LOWERING,
+        translation_key="night_lowering",
+        device_identifier=StoveDeviceIdentifier.STOVE,
+        state_func=lambda x: bool(x != pystove.NIGHT_LOWERING_STATES[0]),
+        turn_off_func=lambda hub: hub.stove.set_night_lowering(False),
+        turn_on_func=lambda hub: hub.stove.set_night_lowering(True),
+    ),
+    HWAMStoveSwitchEntityDescription(
+        key=pystove.DATA_REMOTE_REFILL_ALARM,
+        translation_key="remote_refill_alarm",
+        device_identifier=StoveDeviceIdentifier.REMOTE,
+        turn_off_func=lambda hub: hub.stove.set_remote_refill_alarm(False),
+        turn_on_func=lambda hub: hub.stove.set_remote_refill_alarm(True),
+    ),
+]
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the HWAM Stove binary sensors."""
+    stove_name = config_entry.data[CONF_NAME]
+    stove_hub = hass.data[DATA_HWAM_STOVE][DATA_STOVES][stove_name]
+    async_add_entities(
+        HwamStoveBinarySensor(
+            stove_hub,
+            entity_description,
+        ) for entity_description in SWITCH_DESCRIPTIONS
+    )
+
+
+class HwamStoveBinarySensor(HWAMStoveEntity, SwitchEntity):
+    """Representation of a HWAM Stove switch."""
+
+    entity_description: HWAMStoveSwitchEntityDescription
+
+    @callback
+    def _handle_coordinator_update(self):
+        """Handle status updates from the component."""
+        self._attr_is_on = self.entity_description.state_func(
+            self.coordinator.data[self.entity_description.key]
+        )
+        self.async_schedule_update_ha_state()
+
+    async def async_turn_off(self, **kwargs):
+        """Turn off the switch."""
+        await self.entity_description.turn_off_func(self.coordinator)
+    
+    async def async_turn_on(self, **kwargs):
+        """Turn on the switch."""
+        await self.entity_description.turn_on_func(self.coordinator)

--- a/switch.py
+++ b/switch.py
@@ -68,7 +68,8 @@ async def async_setup_entry(
         HwamStoveBinarySensor(
             stove_hub,
             entity_description,
-        ) for entity_description in SWITCH_DESCRIPTIONS
+        )
+        for entity_description in SWITCH_DESCRIPTIONS
     )
 
 
@@ -92,7 +93,6 @@ class HwamStoveBinarySensor(HWAMStoveEntity, SwitchEntity):
             self._attr_is_on = False
             self.async_schedule_update_ha_state()
 
-    
     async def async_turn_on(self, **kwargs):
         """Turn on the switch."""
         success = await self.entity_description.turn_on_func(self.coordinator)

--- a/translations/en.json
+++ b/translations/en.json
@@ -146,6 +146,14 @@
       "valve_3_position": {
         "name": "Valve 3 Position"
       }
+    },
+    "switch": {
+      "night_lowering": {
+        "name": "Night Lowering"
+      },
+      "remote_refill_alarm": {
+        "name": "Refill Alarm"
+      }
     }
   },
   "issues": {


### PR DESCRIPTION
Add a `switch` platform to replace the `*_night_lowering` and `*_remote_refill_alarm` services.