### PR TITLE
Use the stove id instead of the name to identify the stove

### DIFF
--- a/custom_components/hwam_stove/binary_sensor.py
+++ b/custom_components/hwam_stove/binary_sensor.py
@@ -14,7 +14,7 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntityDescription,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_NAME
+from homeassistant.const import CONF_ID
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -216,8 +216,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the HWAM Stove binary sensors."""
-    stove_name = config_entry.data[CONF_NAME]
-    stove_hub = hass.data[DOMAIN][DATA_STOVES][stove_name]
+    stove_hub = hass.data[DOMAIN][DATA_STOVES][config_entry.data[CONF_ID]]
     async_add_entities(
         HwamStoveBinarySensor(
             stove_hub,

--- a/custom_components/hwam_stove/fan.py
+++ b/custom_components/hwam_stove/fan.py
@@ -15,7 +15,7 @@ from homeassistant.components.fan import (
     FanEntityFeature,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_NAME
+from homeassistant.const import CONF_ID
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -41,8 +41,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the HWAM Stove fan."""
-    stove_name = config_entry.data[CONF_NAME]
-    stove_hub = hass.data[DOMAIN][DATA_STOVES][stove_name]
+    stove_hub = hass.data[DOMAIN][DATA_STOVES][config_entry.data[CONF_ID]]
     stove = StoveBurnLevel(
         stove_hub,
         HWAMStoveFanEntityDescription(

--- a/custom_components/hwam_stove/sensor.py
+++ b/custom_components/hwam_stove/sensor.py
@@ -15,7 +15,7 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_NAME, PERCENTAGE, UnitOfTemperature
+from homeassistant.const import CONF_ID, PERCENTAGE, UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -150,9 +150,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the HWAM Stove sensors."""
-
-    stove_name = config_entry.data[CONF_NAME]
-    stove_device = hass.data[DOMAIN][DATA_STOVES][stove_name]
+    stove_device = hass.data[DOMAIN][DATA_STOVES][config_entry.data[CONF_ID]]
     async_add_entities(
         HwamStoveSensor(
             stove_device,

--- a/custom_components/hwam_stove/switch.py
+++ b/custom_components/hwam_stove/switch.py
@@ -12,7 +12,7 @@ from typing import Any, Callable
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_NAME
+from homeassistant.const import CONF_ID
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -62,8 +62,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the HWAM Stove binary sensors."""
-    stove_name = config_entry.data[CONF_NAME]
-    stove_hub = hass.data[DOMAIN][DATA_STOVES][stove_name]
+    stove_hub = hass.data[DOMAIN][DATA_STOVES][config_entry.data[CONF_ID]]
     async_add_entities(
         HwamStoveBinarySensor(
             stove_hub,


### PR DESCRIPTION
Use the stove id instead of the name to identify the stove in the hass object and in service calls.

The name is not guaranteed to be unique, the id is.