### PR TITLE
Increase time between updates when stove is in standby mode

### DIFF
--- a/custom_components/hwam_stove/coordinator.py
+++ b/custom_components/hwam_stove/coordinator.py
@@ -61,6 +61,10 @@ class StoveCoordinator(DataUpdateCoordinator):
         if data is None:
             raise UpdateFailed("Got empty response")
 
+        self.update_interval = timedelta(
+            seconds=10 if data[pystove.DATA_PHASE] != pystove.PHASE[5] else 60
+        )
+
         dev_reg = dr.async_get(self.hass)
         dev_reg.async_update_device(
             self.stove_device_entry.id,


### PR DESCRIPTION
Use 10 seconds by default, but increase to 60 seconds when the stove is in the `Standby` phase.