### PR TITLE
Update entity descriptions

### DIFF
--- a/custom_components/hwam_stove/datetime.py
+++ b/custom_components/hwam_stove/datetime.py
@@ -41,6 +41,7 @@ TIME_DESCRIPTIONS = [
         translation_key="date_and_time",
         device_identifier=StoveDeviceIdentifier.STOVE,
         set_func=lambda hub, date_time: hub.stove.set_time(date_time),
+        entity_registry_enabled_default=False,
     ),
 ]
 

--- a/custom_components/hwam_stove/sensor.py
+++ b/custom_components/hwam_stove/sensor.py
@@ -107,6 +107,7 @@ SENSOR_DESCRIPTIONS = [
         device_identifier=StoveDeviceIdentifier.STOVE,
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:message-processing",
+        entity_registry_enabled_default=False,
     ),
     HWAMStoveSensorEntityDescription(
         key=pystove.DATA_NEW_FIREWOOD_ESTIMATE,
@@ -182,6 +183,8 @@ SENSOR_DESCRIPTIONS = [
         device_class=SensorDeviceClass.DURATION,
         native_unit_of_measurement=UnitOfTime.SECONDS,
         entity_category=EntityCategory.DIAGNOSTIC,
+        suggested_unit_of_measurement=UnitOfTime.HOURS,
+        suggested_display_precision=2,
     ),
     HWAMStoveSensorEntityDescription(
         key=pystove.DATA_TIME_TO_NEW_FIREWOOD,
@@ -191,6 +194,8 @@ SENSOR_DESCRIPTIONS = [
         native_unit_of_measurement=UnitOfTime.SECONDS,
         state_func=lambda data, key: data[key].seconds,
         entity_category=EntityCategory.DIAGNOSTIC,
+        suggested_unit_of_measurement=UnitOfTime.HOURS,
+        suggested_display_precision=2,
     ),
     HWAMStoveSensorEntityDescription(
         key=pystove.DATA_VALVE1_POSITION,


### PR DESCRIPTION
* Set suggested units and precision on duration sensors
* Disable chatty entities (date/time and message ID) by default

fixes #29 
fixes #30 
