### PR TITLE
Remove stove_id

### DIFF
--- a/custom_components/hwam_stove/__init__.py
+++ b/custom_components/hwam_stove/__init__.py
@@ -9,13 +9,7 @@ from asyncio import CancelledError
 import logging
 
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry, ConfigEntryNotReady
-from homeassistant.const import (
-    CONF_HOST,
-    CONF_ID,
-    CONF_MONITORED_VARIABLES,
-    CONF_NAME,
-    Platform,
-)
+from homeassistant.const import CONF_HOST, CONF_MONITORED_VARIABLES, CONF_NAME, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv, issue_registry as ir
 from homeassistant.helpers.typing import ConfigType
@@ -69,7 +63,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         raise ConfigEntryNotReady() from e
 
     stove_hub = StoveCoordinator(hass, stove, config_entry)
-    hass.data[DOMAIN][DATA_STOVES][config_entry.data[CONF_ID]] = stove_hub
+    hass.data[DOMAIN][DATA_STOVES][config_entry.entry_id] = stove_hub
 
     await stove_hub.async_config_entry_first_refresh()
 
@@ -109,10 +103,10 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
     if unload_ok := await hass.config_entries.async_unload_platforms(
         config_entry, PLATFORMS
     ):
-        stove_hub = hass.data[DOMAIN][DATA_STOVES][config_entry.data[CONF_ID]]
+        stove_hub = hass.data[DOMAIN][DATA_STOVES][config_entry.entry_id]
         await stove_hub.stove.destroy()
 
-        hass.data[DOMAIN][DATA_STOVES].pop(config_entry.data[CONF_ID])
+        hass.data[DOMAIN][DATA_STOVES].pop(config_entry.entry_id)
         if hass.data[DOMAIN][DATA_STOVES] == {}:
             hass.data[DOMAIN].pop(DATA_STOVES)
             # DATA_STOVES is the only key in hass.data[DOMAIN] at the moment...

--- a/custom_components/hwam_stove/binary_sensor.py
+++ b/custom_components/hwam_stove/binary_sensor.py
@@ -14,7 +14,7 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntityDescription,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_ID, EntityCategory
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -217,7 +217,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the HWAM Stove binary sensors."""
-    stove_hub = hass.data[DOMAIN][DATA_STOVES][config_entry.data[CONF_ID]]
+    stove_hub = hass.data[DOMAIN][DATA_STOVES][config_entry.entry_id]
     async_add_entities(
         HwamStoveBinarySensor(
             stove_hub,

--- a/custom_components/hwam_stove/button.py
+++ b/custom_components/hwam_stove/button.py
@@ -12,7 +12,7 @@ from typing import Any, Callable
 
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_ID, EntityCategory
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -59,7 +59,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the HWAM Stove buttons."""
-    stove_hub = hass.data[DOMAIN][DATA_STOVES][config_entry.data[CONF_ID]]
+    stove_hub = hass.data[DOMAIN][DATA_STOVES][config_entry.entry_id]
     async_add_entities(
         HwamStoveButton(
             stove_hub.stove,

--- a/custom_components/hwam_stove/config_flow.py
+++ b/custom_components/hwam_stove/config_flow.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
-from homeassistant.const import CONF_HOST, CONF_ID, CONF_NAME
-import homeassistant.helpers.config_validation as cv
+from homeassistant.const import CONF_HOST, CONF_NAME
 import voluptuous as vol
 
 from pystove import pystove
@@ -26,12 +25,8 @@ class HWAMStoveConfigFlow(ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
         if info:
             name = info[CONF_NAME]
             host = info[CONF_HOST]
-            stove_id = cv.slugify(info.get(CONF_NAME, name))
 
             entries = [e.data for e in self._async_current_entries()]
-
-            if stove_id in [e[CONF_ID] for e in entries]:
-                return self._show_form({"base": "id_exists"})
 
             if host in [e[CONF_HOST] for e in entries]:
                 return self._show_form({"base": "already_configured"})
@@ -51,7 +46,7 @@ class HWAMStoveConfigFlow(ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
             except ConnectionError:
                 return self._show_form({"base": "cannot_connect"})
 
-            return self._create_entry(stove_id, name, host)
+            return self._create_entry(name, host)
 
         return self._show_form()
 
@@ -80,14 +75,13 @@ class HWAMStoveConfigFlow(ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
                 {
                     vol.Required(CONF_NAME): str,
                     vol.Required(CONF_HOST): str,
-                    vol.Optional(CONF_ID): str,
                 }
             ),
             errors=errors or {},
         )
 
-    def _create_entry(self, stove_id: str, name: str, host: str) -> ConfigFlowResult:
+    def _create_entry(self, name: str, host: str) -> ConfigFlowResult:
         """Create entry for the HWAM Stove."""
         return self.async_create_entry(
-            title=name, data={CONF_ID: stove_id, CONF_HOST: host, CONF_NAME: name}
+            title=name, data={CONF_HOST: host, CONF_NAME: name}
         )

--- a/custom_components/hwam_stove/coordinator.py
+++ b/custom_components/hwam_stove/coordinator.py
@@ -5,7 +5,7 @@ import logging
 from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_ID, CONF_NAME
+from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -41,16 +41,19 @@ class StoveCoordinator(DataUpdateCoordinator):
         self.stove = stove
 
         dev_reg = dr.async_get(hass)
-        hub_id = config_entry.data[CONF_ID]
         self.stove_device_entry = dev_reg.async_get_or_create(
             config_entry_id=config_entry.entry_id,
-            identifiers={(DOMAIN, f"{hub_id}-{StoveDeviceIdentifier.STOVE}")},
+            identifiers={
+                (DOMAIN, f"{config_entry.entry_id}-{StoveDeviceIdentifier.STOVE}")
+            },
             manufacturer="HWAM",
             translation_key="hwam_stove_device",
         )
         self.remote_device_entry = dev_reg.async_get_or_create(
             config_entry_id=config_entry.entry_id,
-            identifiers={(DOMAIN, f"{hub_id}-{StoveDeviceIdentifier.REMOTE}")},
+            identifiers={
+                (DOMAIN, f"{config_entry.entry_id}-{StoveDeviceIdentifier.REMOTE}")
+            },
             manufacturer="HWAM",
             translation_key="hwam_remote_device",
         )

--- a/custom_components/hwam_stove/datetime.py
+++ b/custom_components/hwam_stove/datetime.py
@@ -13,7 +13,7 @@ from typing import Any, Callable
 
 from homeassistant.components.datetime import DateTimeEntity, DateTimeEntityDescription
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_ID, EntityCategory
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util.dt import get_default_time_zone
@@ -54,7 +54,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the HWAM Stove datetime entities."""
-    stove_device = hass.data[DOMAIN][DATA_STOVES][config_entry.data[CONF_ID]]
+    stove_device = hass.data[DOMAIN][DATA_STOVES][config_entry.entry_id]
     async_add_entities(
         HwamStoveTime(
             stove_device,

--- a/custom_components/hwam_stove/entity.py
+++ b/custom_components/hwam_stove/entity.py
@@ -1,7 +1,6 @@
 """Common HWAM Stove entity properties."""
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_ID
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import Entity, EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -32,7 +31,7 @@ class HWAMStoveBaseEntity(Entity):
         entity_description: HWAMStoveEntityDescription,
     ) -> None:
         """Initialize the entity."""
-        hub_id = config_entry.data[CONF_ID]
+        hub_id = config_entry.entry_id
         self._attr_unique_id = f"{hub_id}-{entity_description.key}"
         self._attr_device_info = DeviceInfo(
             identifiers={

--- a/custom_components/hwam_stove/number.py
+++ b/custom_components/hwam_stove/number.py
@@ -12,7 +12,6 @@ from typing import Any, Callable
 
 from homeassistant.components.number import NumberEntity, NumberEntityDescription
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_ID
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -56,7 +55,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the HWAM Stove number entities."""
-    stove_hub = hass.data[DOMAIN][DATA_STOVES][config_entry.data[CONF_ID]]
+    stove_hub = hass.data[DOMAIN][DATA_STOVES][config_entry.entry_id]
     async_add_entities(
         HwamStoveNumber(
             stove_hub,

--- a/custom_components/hwam_stove/sensor.py
+++ b/custom_components/hwam_stove/sensor.py
@@ -18,7 +18,6 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
-    CONF_ID,
     PERCENTAGE,
     EntityCategory,
     UnitOfTemperature,
@@ -232,7 +231,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the HWAM Stove sensors."""
-    stove_device = hass.data[DOMAIN][DATA_STOVES][config_entry.data[CONF_ID]]
+    stove_device = hass.data[DOMAIN][DATA_STOVES][config_entry.entry_id]
     async_add_entities(
         HwamStoveSensor(
             stove_device,

--- a/custom_components/hwam_stove/switch.py
+++ b/custom_components/hwam_stove/switch.py
@@ -12,7 +12,7 @@ from typing import Any, Callable
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_ID, EntityCategory
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -64,7 +64,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the HWAM Stove binary sensors."""
-    stove_hub = hass.data[DOMAIN][DATA_STOVES][config_entry.data[CONF_ID]]
+    stove_hub = hass.data[DOMAIN][DATA_STOVES][config_entry.entry_id]
     async_add_entities(
         HwamStoveBinarySensor(
             stove_hub,

--- a/custom_components/hwam_stove/time.py
+++ b/custom_components/hwam_stove/time.py
@@ -13,7 +13,7 @@ from typing import Any, Callable
 
 from homeassistant.components.time import TimeEntity, TimeEntityDescription
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_ID, EntityCategory
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -64,7 +64,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the HWAM Stove time entities."""
-    stove_device = hass.data[DOMAIN][DATA_STOVES][config_entry.data[CONF_ID]]
+    stove_device = hass.data[DOMAIN][DATA_STOVES][config_entry.entry_id]
     async_add_entities(
         HwamStoveTime(
             stove_device,

--- a/custom_components/hwam_stove/translations/de.json
+++ b/custom_components/hwam_stove/translations/de.json
@@ -4,14 +4,12 @@
       "init": {
         "data": {
           "name": "Name",
-          "host": "Host",
-          "id": "ID"
+          "host": "Host"
         }
       }
     },
     "error": {
       "already_configured": "Host bereits konfiguriert",
-      "id_exists": "ID existiert bereits",
       "cannot_connect": "Kann nicht mit Host verbinden"
     }
   },

--- a/custom_components/hwam_stove/translations/en.json
+++ b/custom_components/hwam_stove/translations/en.json
@@ -4,14 +4,12 @@
       "init": {
         "data": {
           "name": "Name",
-          "host": "Host",
-          "id": "ID"
+          "host": "Host"
         }
       }
     },
     "error": {
       "already_configured": "Host already configured",
-      "id_exists": "ID already exists",
       "cannot_connect": "Can not connect to host"
     }
   },

--- a/custom_components/hwam_stove/translations/nl.json
+++ b/custom_components/hwam_stove/translations/nl.json
@@ -4,14 +4,12 @@
       "init": {
         "data": {
           "name": "Naam",
-          "host": "Hostnaam of IP",
-          "id": "ID"
+          "host": "Hostnaam of IP"
         }
       }
     },
     "error": {
       "already_configured": "Kachel is al geconfigureerd",
-      "id_exists": "ID bestaat al",
       "cannot_connect": "Kan geen verbinding maken met de kachel"
     }
   },


### PR DESCRIPTION
Remove the stove_id from the config flow and stop using it in the integration.
Since service actions were converted to config entities the stove_id is no longer needed to identify the stove we want to configure.

Fixes #48